### PR TITLE
update release nonreleaseメソッドにおいて、comicの検索をbefore_actionで行えるようにする

### DIFF
--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -91,12 +91,12 @@ class ComicsController < ApplicationController
   end
 
   def release
-    @comic.released! unless @comic.released?
+    @comic.released!
     redirect_to edit_comic_path, notice: 'この作品を公開しました'
   end
 
   def nonrelease
-    @comic.nonreleased! unless @comic.nonreleased?
+    @comic.nonreleased!
     redirect_to edit_comic_path, notice: 'この作品を非公開にしました'
   end
 

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -1,6 +1,7 @@
 class ComicsController < ApplicationController
-  before_action :set_comic, only: [:show, :edit, :update, :destroy]
+  before_action :set_comic, only: [:show, :edit, :update, :destroy, :release, :nonrelease]
   before_action :authenticate_user!, only: [:show, :new, :edit, :destroy, :like, :unlike]
+
 
   # GET /comics
   # GET /comics.json
@@ -90,14 +91,12 @@ class ComicsController < ApplicationController
   end
 
   def release
-    comic =  Comic.find(params[:id])
-    comic.released! unless comic.released?
+    @comic.released! unless @comic.released?
     redirect_to edit_comic_path, notice: 'この作品を公開しました'
   end
 
   def nonrelease
-    comic =  Comic.find(params[:id])
-    comic.nonreleased! unless comic.nonreleased?
+    @comic.nonreleased! unless @comic.nonreleased?
     redirect_to edit_comic_path, notice: 'この作品を非公開にしました'
   end
 


### PR DESCRIPTION
set_comicに統一

質問なんですが、これってインスタンス変数でないと、before_actionから変数渡せませんか？
一度、　comic = Comic.find(params[:id])でbefore_action作ってハマってたんですが。。。。。


すみません。自分で色々調べたんですが、comicはbefore_Action内で定義したローカル変数だから、releaseメソッドでは使えず、@comicはインスタンス変数で他のメソッドでも利用可能だから問題ないという理解で良いですか？